### PR TITLE
Fix tunnel session lifecycle leaks

### DIFF
--- a/bidi/bidi.go
+++ b/bidi/bidi.go
@@ -21,25 +21,44 @@ import (
 	"io"
 )
 
+type closeWriter interface {
+	CloseWrite() error
+}
+
 // Copy starts bi-directional copying between two read write closers.
 func Copy(i, j io.ReadWriteCloser) error {
 	errCh := make(chan error, 2)
 
-	copy := func(in, out io.ReadWriteCloser) {
-		defer in.Close()
-		_, err := io.Copy(in, out)
+	copy := func(dst, src io.ReadWriteCloser) {
+		_, err := io.Copy(dst, src)
+		if err == nil || err == io.EOF {
+			if w, ok := dst.(closeWriter); ok {
+				err = w.CloseWrite()
+			} else {
+				err = dst.Close()
+			}
+		}
 		errCh <- err
 	}
 
 	go copy(i, j)
 	go copy(j, i)
 
-	err := <-errCh
-	// Explicitly ignoring the second error as it's most likely io.EOF; however,
-	// we're still waiting for the second error to ensure the go-routines have completed.
-	<-errCh
-	if err == io.EOF {
+	firstErr := <-errCh
+	if firstErr != nil && firstErr != io.EOF {
+		// A terminal error in either direction must tear down both sides. Do not
+		// wait for the second copy: returning lets an owning gRPC handler exit and
+		// cancel a Recv that cannot otherwise be interrupted from server code.
+		_ = i.Close()
+		_ = j.Close()
+		return firstErr
+	}
+
+	secondErr := <-errCh
+	_ = i.Close()
+	_ = j.Close()
+	if secondErr == io.EOF {
 		return nil
 	}
-	return err
+	return secondErr
 }

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -815,7 +815,16 @@ func (s *Server) newClientSession(ctx context.Context, session *tpb.Session, add
 	tag := session.GetTag()
 	if session.GetError() != "" {
 		if ch := s.connection(tag, addr); ch != nil {
-			ch <- ioOrErr{err: errors.New(session.GetError())}
+			// Deliver without blocking: the waiter in handleSession may have
+			// abandoned this channel on context cancelation. A bare send here
+			// would permanently wedge this client's Register goroutine, which
+			// in turn leaks the client's target registrations even after the
+			// underlying connection dies.
+			select {
+			case ch <- ioOrErr{err: errors.New(session.GetError())}:
+			default:
+				s.sendError(fmt.Errorf("dropping session error for tag %v: no receiver: %s", tag, session.GetError()))
+			}
 			return
 		}
 		s.sendError(fmt.Errorf("no connection associated with tag: %v", tag))
@@ -843,7 +852,9 @@ func (s *Server) newClientSession(ctx context.Context, session *tpb.Session, add
 		return
 	}
 
-	retCh := make(chan ioOrErr)
+	// Buffered so a response delivered after this function abandons the wait
+	// below never blocks the sender.
+	retCh := make(chan ioOrErr, 1)
 	if err := s.addConnection(tag, addr, retCh); err != nil {
 		if err := rs.Send(&tpb.RegisterOp{Registration: &tpb.RegisterOp_Session{Session: &tpb.Session{Tag: tag, Error: err.Error()}}}); err != nil {
 			s.sendError(fmt.Errorf("failed to send session error: %v", err))
@@ -864,6 +875,17 @@ func (s *Server) newClientSession(ctx context.Context, session *tpb.Session, add
 	// ctx is a child of the register stream's context
 	select {
 	case <-ctx.Done():
+		// Remove the connection so no new sender can pick it up, then drain a
+		// response that may already be buffered so its tunnel stream is
+		// released rather than leaked.
+		s.deleteConnection(tag, addr)
+		select {
+		case ioe := <-retCh:
+			if ioe.rwc != nil {
+				ioe.rwc.Close()
+			}
+		default:
+		}
 		s.sendError(ctx.Err())
 		return
 	case ioe := <-retCh:
@@ -912,7 +934,14 @@ func (s *Server) Tunnel(stream tpb.Tunnel_TunnelServer) error {
 		return errors.New("no connection associated with tag")
 	}
 	d := newIOStream(stream.Context(), stream)
-	ch <- ioOrErr{rwc: d}
+	// Deliver without blocking: the session waiter may have abandoned the
+	// channel after this handler looked it up. The channel is buffered, so a
+	// hit on the default case means another response already claimed it.
+	select {
+	case ch <- ioOrErr{rwc: d}:
+	default:
+		return fmt.Errorf("no receiver for tunnel stream with tag %d: session abandoned", tag)
+	}
 	// doneCh is the done channel created from a child context of stream.Context()
 	<-d.doneCh
 	return nil
@@ -1076,7 +1105,11 @@ func (s *Server) NewSession(ctx context.Context, ss ServerSession) (io.ReadWrite
 }
 
 func (s *Server) handleSession(ctx context.Context, tag int32, addr net.Addr, target Target, stream regStream) (_ io.ReadWriteCloser, err error) {
-	retCh := make(chan ioOrErr)
+	// Buffered so a response delivered after this function abandons the wait
+	// below (ctx canceled) never blocks the sender. The sender is the
+	// client's Register goroutine, and blocking it permanently leaks the
+	// client's target registrations even after the connection dies.
+	retCh := make(chan ioOrErr, 1)
 	if err = s.addConnection(tag, addr, retCh); err != nil {
 		return nil, fmt.Errorf("handleSession: failed to add connection: %v", err)
 	}
@@ -1096,6 +1129,18 @@ func (s *Server) handleSession(ctx context.Context, tag int32, addr net.Addr, ta
 	}
 	select {
 	case <-ctx.Done():
+		// Remove the connection so no new sender can pick it up, then drain a
+		// response that may already be buffered so its tunnel stream is
+		// released rather than leaked. The deferred deleteConnection is then
+		// a no-op.
+		s.deleteConnection(tag, addr)
+		select {
+		case ioe := <-retCh:
+			if ioe.rwc != nil {
+				ioe.rwc.Close()
+			}
+		default:
+		}
 		return nil, ctx.Err()
 	case ioe := <-retCh:
 		if ioe.err != nil {

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -75,15 +75,22 @@ func (d *dataSafeStream) Send(data *tpb.Data) error {
 
 // ioStream defines a gRPC stream that implements io.ReadWriteCloser.
 type ioStream struct {
-	buf    []byte
-	doneCh <-chan struct{}
-	cancel context.CancelFunc
+	buf       []byte
+	doneCh    <-chan struct{}
+	cancel    context.CancelFunc
+	closeOnce sync.Once
 	dataSafeStream
 }
 
 // newIOStream creates and returns a stream which implements io.ReadWriteCloser.
 func newIOStream(ctx context.Context, d dataStream) *ioStream {
 	ctx, cancel := context.WithCancel(ctx)
+	return newIOStreamWithCancel(ctx, d, cancel)
+}
+
+// newIOStreamWithCancel creates an IO stream whose Close method cancels the
+// context that owns the underlying gRPC stream.
+func newIOStreamWithCancel(ctx context.Context, d dataStream, cancel context.CancelFunc) *ioStream {
 	return &ioStream{
 		dataSafeStream: dataSafeStream{
 			dataStream: d,
@@ -133,10 +140,17 @@ func (s *ioStream) Write(b []byte) (int, error) {
 	}
 }
 
-// Close implements io.Closer.
-func (s *ioStream) Close() error {
-	s.cancel()
+// CloseWrite signals that no more data will be written while leaving the read
+// direction open.
+func (s *ioStream) CloseWrite() error {
 	return s.Send(&tpb.Data{Close: true})
+}
+
+// Close implements io.Closer and terminates the context that owns the gRPC
+// stream. The cancellation is idempotent and unblocks an in-flight Recv.
+func (s *ioStream) Close() error {
+	s.closeOnce.Do(s.cancel)
+	return nil
 }
 
 // session defines a unique connection for the tunnel.
@@ -231,8 +245,8 @@ func (s *Server) bridgeRegHandler(ss ServerSession) error {
 	return nil
 }
 
-func (s *Server) bridgeHandler(ss ServerSession, rwc io.ReadWriteCloser) error {
-	ctx, cancel := context.WithCancel(context.Background())
+func (s *Server) bridgeHandler(ctx context.Context, ss ServerSession, rwc io.ReadWriteCloser) error {
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	addr := s.clientFromTarget(ss.Target)
@@ -326,18 +340,20 @@ func (s *Server) clientInfo(addr net.Addr) clientRegInfo {
 
 // clientTargets returns all the targets of a given client. If addr is nil, return all the targets.
 func (s *Server) clientTargets(addr net.Addr) map[Target]struct{} {
-	s.cmu.RLock()
-	defer s.cmu.RUnlock()
 	// Make a deep copy.
 	targets := make(map[Target]struct{})
 
 	if addr == nil {
+		s.tmu.RLock()
+		defer s.tmu.RUnlock()
 		for t := range s.rTargets {
 			targets[t] = struct{}{}
 		}
 		return targets
 	}
 
+	s.cmu.RLock()
+	defer s.cmu.RUnlock()
 	info, ok := s.clients[addr]
 	if !ok {
 		return nil
@@ -862,6 +878,7 @@ func (s *Server) newClientSession(ctx context.Context, session *tpb.Session, add
 		}
 		return
 	}
+	defer s.deleteConnection(tag, addr)
 
 	if err := rs.Send(&tpb.RegisterOp{Registration: &tpb.RegisterOp_Session{Session: &tpb.Session{
 		Tag:        session.Tag,
@@ -893,13 +910,14 @@ func (s *Server) newClientSession(ctx context.Context, session *tpb.Session, add
 			return
 		}
 		go func() {
+			defer ioe.rwc.Close()
 			// If client is requesting a remote target, only call the bridge handler.
 			// We might extend it to allow calling the customized handler in the future.
 			var err error
 			tc := s.clientFromTarget(t)
 			switch {
 			case tc != nil:
-				err = s.bridgeHandler(ServerSession{addr, t}, ioe.rwc)
+				err = s.bridgeHandler(ctx, ServerSession{addr, t}, ioe.rwc)
 			case s.sc.Handler != nil:
 				err = s.sc.Handler(ServerSession{addr, t}, ioe.rwc)
 			default:
@@ -1036,7 +1054,7 @@ func (c *Client) deletePeerTarget(t *tpb.Target) error {
 	c.pmu.Lock()
 	defer c.pmu.Unlock()
 
-	if _, ok := c.peerTypeTargets[t.TargetType]; !ok {
+	if _, ok := c.peerTypeTargets[t.TargetType]; ok {
 		delete(c.peerTypeTargets[t.TargetType], Target{ID: t.Target, Type: t.TargetType})
 	}
 	if c.cc.PeerDelHandler != nil {
@@ -1113,11 +1131,7 @@ func (s *Server) handleSession(ctx context.Context, tag int32, addr net.Addr, ta
 	if err = s.addConnection(tag, addr, retCh); err != nil {
 		return nil, fmt.Errorf("handleSession: failed to add connection: %v", err)
 	}
-	defer func() {
-		if err != nil {
-			s.deleteConnection(tag, addr)
-		}
-	}()
+	defer s.deleteConnection(tag, addr)
 
 	if err = stream.Send(&tpb.RegisterOp{Registration: &tpb.RegisterOp_Session{Session: &tpb.Session{
 		Tag:        tag,
@@ -1183,6 +1197,7 @@ type Client struct {
 	cmu  sync.RWMutex
 	rs   *regSafeStream
 	addr net.Addr // peer address to use in endpoint map
+	ctx  context.Context
 
 	targets map[Target]struct{}
 
@@ -1197,15 +1212,16 @@ type Client struct {
 // cancel performs cancellations of Start() and streamHandler(), and records error.
 func (c *Client) cancel(err error) {
 	c.emu.Lock()
-	defer c.emu.Unlock()
 	// Avoid calling multiple times.
 	if c.cancelFunc == nil {
+		c.emu.Unlock()
 		return
 	}
-
-	c.cancelFunc()
+	cancel := c.cancelFunc
 	c.cancelFunc = nil
 	c.err = err
+	c.emu.Unlock()
+	cancel()
 }
 
 // Error returns the error collected from streamHandler.
@@ -1243,59 +1259,111 @@ func NewClient(tc tpb.TunnelClient, cc ClientConfig, ts map[Target]struct{}) (*C
 
 // NewSession requests a new stream identified on the server side by target.
 func (c *Client) NewSession(target Target) (_ io.ReadWriteCloser, err error) {
+	return c.NewSessionContext(context.Background(), target)
+}
+
+// NewSessionContext requests a new stream and abandons the request when ctx or
+// the active registration context is canceled.
+func (c *Client) NewSessionContext(ctx context.Context, target Target) (_ io.ReadWriteCloser, err error) {
 	c.cmu.RLock()
-	defer c.cmu.RUnlock()
-	if c.addr == nil {
+	addr, rs, registerCtx := c.addr, c.rs, c.ctx
+	c.cmu.RUnlock()
+	if addr == nil || rs == nil || registerCtx == nil {
 		return nil, errors.New("client not started")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := registerCtx.Err(); err != nil {
+		return nil, err
 	}
 	retCh := make(chan ioOrErr, 1)
 	tag := c.nextTag()
-	if err = c.addConnection(tag, c.addr, retCh); err != nil {
+	if err = c.addConnection(tag, addr, retCh); err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err != nil {
-			c.deleteConnection(tag, c.addr)
-		}
-	}()
-	if err = c.rs.Send(&tpb.RegisterOp{Registration: &tpb.RegisterOp_Session{Session: &tpb.Session{
+	defer c.deleteConnection(tag, addr)
+	if err = rs.Send(&tpb.RegisterOp{Registration: &tpb.RegisterOp_Session{Session: &tpb.Session{
 		Tag:        tag,
 		Target:     target.ID,
 		TargetType: target.Type,
 	}}}); err != nil {
 		return nil, err
 	}
-	ioe := <-retCh
-	if ioe.err != nil {
-		return nil, ioe.err
+	var cancelErr error
+	select {
+	case <-ctx.Done():
+		cancelErr = ctx.Err()
+	case <-registerCtx.Done():
+		cancelErr = registerCtx.Err()
+	case ioe := <-retCh:
+		if ioe.err != nil {
+			return nil, ioe.err
+		}
+		return ioe.rwc, nil
 	}
-	return ioe.rwc, nil
+	// Prevent a racing returnedStream from delivering after this request has
+	// been abandoned. If it already won that race, close the buffered stream.
+	c.deleteConnection(tag, addr)
+	select {
+	case ioe := <-retCh:
+		if ioe.rwc != nil {
+			_ = ioe.rwc.Close()
+		}
+	default:
+	}
+	return nil, cancelErr
 }
 
 // Register initializes the client register stream and determines the
 // capabilities of the tunnel server.
 func (c *Client) Register(ctx context.Context) (err error) {
-	c.cmu.Lock()
-	defer c.cmu.Unlock()
+	ctx, cancel := context.WithCancel(ctx)
+	c.emu.Lock()
+	c.cancelFunc = cancel
+	c.err = nil
+	c.emu.Unlock()
+	defer func() {
+		if err != nil {
+			c.cancel(err)
+		}
+	}()
 
-	ctx, c.cancelFunc = context.WithCancel(ctx)
 	stream, err := c.tc.Register(ctx, c.cc.Opts...)
 	if err != nil {
 		return fmt.Errorf("start: failed to create register stream: %v", err)
 	}
-	c.rs = &regSafeStream{regStream: stream}
 	p, ok := peer.FromContext(stream.Context())
 	if !ok {
 		return errors.New("no peer from stream context")
 	}
+	rs := &regSafeStream{regStream: stream}
+	c.cmu.Lock()
+	c.ctx = ctx
+	c.rs = rs
 	c.addr = p.Addr
+	c.cmu.Unlock()
 
 	for target := range c.targets {
-		c.NewTarget(target)
+		if err := rs.Send(&tpb.RegisterOp{Registration: &tpb.RegisterOp_Target{Target: &tpb.Target{
+			Target:     target.ID,
+			Op:         tpb.Target_ADD,
+			TargetType: target.Type,
+		}}}); err != nil {
+			return fmt.Errorf("failed to register target %q: %v", target.ID, err)
+		}
 	}
 
+	c.pmu.RLock()
+	subscriptions := make([]string, 0, len(c.peerTypeTargets))
 	for typ := range c.peerTypeTargets {
-		c.Subscribe(typ)
+		subscriptions = append(subscriptions, typ)
+	}
+	c.pmu.RUnlock()
+	for _, typ := range subscriptions {
+		if err := c.Subscribe(typ); err != nil {
+			return fmt.Errorf("failed to subscribe to target type %q: %v", typ, err)
+		}
 	}
 
 	return nil
@@ -1315,23 +1383,35 @@ func (c *Client) Run(ctx context.Context) error {
 // Start handles received register stream requests.
 func (c *Client) Start(ctx context.Context) {
 	var err error
-	defer func() {
-		c.cancel(err)
-	}()
-
 	select {
 	case c.block <- struct{}{}:
 		defer func() {
 			<-c.block
 		}()
 	default:
-		err = errors.New("client is already running")
+		c.emu.Lock()
+		c.err = errors.New("client is already running")
+		c.emu.Unlock()
 		return
 	}
+	defer func() {
+		c.cancel(err)
+	}()
+	c.cmu.RLock()
+	registerCtx, rs := c.ctx, c.rs
+	c.cmu.RUnlock()
+	if registerCtx == nil || rs == nil {
+		err = errors.New("client not registered")
+		return
+	}
+	handlerCtx, cancelHandlers := context.WithCancel(registerCtx)
+	stopCancel := context.AfterFunc(ctx, cancelHandlers)
+	defer stopCancel()
+	defer cancelHandlers()
 
 	for {
 		var reg *tpb.RegisterOp
-		reg, err = c.rs.Recv()
+		reg, err = rs.Recv()
 		if err != nil {
 			return
 		}
@@ -1347,7 +1427,7 @@ func (c *Client) Start(ctx context.Context) {
 			tID := session.GetTarget()
 			tType := session.GetTargetType()
 			go func() {
-				if err := c.streamHandler(ctx, tag, Target{ID: tID, Type: tType}); err != nil {
+				if err := c.streamHandler(handlerCtx, tag, Target{ID: tID, Type: tType}); err != nil {
 					c.cancel(err)
 				}
 			}()
@@ -1422,21 +1502,35 @@ func (c *Client) streamHandler(ctx context.Context, tag int32, t Target) (e erro
 // A tag which is less than 0 indicates the stream originated at the client.
 func (c *Client) returnedStream(ctx context.Context, tag int32) (err error) {
 	c.cmu.RLock()
-	defer c.cmu.RUnlock()
-	ch := c.connection(tag, c.addr)
+	addr, rs := c.addr, c.rs
+	c.cmu.RUnlock()
+	ch := c.connection(tag, addr)
 	if ch == nil {
-		return fmt.Errorf("No connection associated with tag: %d", tag)
+		if rs == nil {
+			return fmt.Errorf("no connection associated with tag: %d", tag)
+		}
+		return rs.Send(&tpb.RegisterOp{Registration: &tpb.RegisterOp_Session{Session: &tpb.Session{
+			Tag:   tag,
+			Error: fmt.Sprintf("no connection associated with tag: %d", tag),
+		}}})
 	}
-	// notify client session of error, and return error to be sent to server.
-	var rwc io.ReadWriteCloser
-	defer func() {
-		ch <- ioOrErr{rwc: rwc, err: err}
-	}()
-	rwc, err = c.newTunnelStream(ctx, tag)
+	rwc, err := c.newTunnelStream(ctx, tag)
 	if err != nil {
+		select {
+		case ch <- ioOrErr{err: err}:
+		default:
+		}
 		return err
 	}
-	return nil
+	if c.connection(tag, addr) != ch {
+		return rwc.Close()
+	}
+	select {
+	case ch <- ioOrErr{rwc: rwc}:
+		return nil
+	default:
+		return rwc.Close()
+	}
 }
 
 // handleNewClientStream is called when the tag is greater than 0, and the client
@@ -1446,6 +1540,7 @@ func (c *Client) newClientStream(ctx context.Context, tag int32, t Target) error
 	if err != nil {
 		return err
 	}
+	defer stream.Close()
 	if c.cc.Handler == nil {
 		return fmt.Errorf("no Handler provided")
 	}
@@ -1455,12 +1550,15 @@ func (c *Client) newClientStream(ctx context.Context, tag int32, t Target) error
 // newTunnelStream creates a new tunnel stream and sends tag to the server. The
 // server uses this tag to uniquely identify the connection.
 func (c *Client) newTunnelStream(ctx context.Context, tag int32) (*ioStream, error) {
-	ts, err := c.tc.Tunnel(ctx, c.cc.Opts...)
+	streamCtx, cancel := context.WithCancel(ctx)
+	ts, err := c.tc.Tunnel(streamCtx, c.cc.Opts...)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 	if err = ts.Send(&tpb.Data{Tag: tag}); err != nil {
+		cancel()
 		return nil, err
 	}
-	return newIOStream(ctx, ts), nil
+	return newIOStreamWithCancel(streamCtx, ts, cancel), nil
 }

--- a/tunnel/tunnel_deadlock_test.go
+++ b/tunnel/tunnel_deadlock_test.go
@@ -1,0 +1,102 @@
+package tunnel
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/peer"
+
+	tpb "github.com/openconfig/grpctunnel/proto/tunnel"
+)
+
+// These are regression tests for a registration-leak deadlock: a session
+// response delivered after its handleSession waiter abandoned retCh (context
+// cancelation) must never block the sender. The senders are the client's
+// Register goroutine and Tunnel stream handlers; blocking the Register
+// goroutine prevents its deferred cleanup from ever running, so the client's
+// target registrations outlive the connection and permanently lock the
+// target ID out of re-registration.
+
+const deadlockTimeout = 5 * time.Second
+
+// abandonedConnection registers a connection whose buffered response slot is
+// already taken and which has no reader, emulating a waiter that gave up
+// after a response was delivered.
+func abandonedConnection(t *testing.T, s *Server, tag int32, addr net.Addr) {
+	t.Helper()
+	retCh := make(chan ioOrErr, 1)
+	retCh <- ioOrErr{}
+	if err := s.addConnection(tag, addr, retCh); err != nil {
+		t.Fatalf("failed to add connection to test server: %v", err)
+	}
+}
+
+func TestNewClientSessionErrorDoesNotBlockWithoutReceiver(t *testing.T) {
+	s, err := NewServer(ServerConfig{})
+	if err != nil {
+		t.Fatalf("NewServer(ServerConfig{}) failed: %v", err)
+	}
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:45000")
+	if err != nil {
+		t.Fatalf("failed to resolve address: %v", err)
+	}
+	abandonedConnection(t, s, 1, addr)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.newClientSession(context.Background(), &tpb.Session{Tag: 1, Error: "session failed"}, addr, &regSafeStream{})
+	}()
+	select {
+	case <-done:
+	case <-time.After(deadlockTimeout):
+		t.Fatal("newClientSession blocked delivering a session error with no receiver; this wedges the client's Register goroutine")
+	}
+}
+
+func TestServerTunnelDoesNotBlockWithoutReceiver(t *testing.T) {
+	s, err := NewServer(ServerConfig{})
+	if err != nil {
+		t.Fatalf("NewServer(ServerConfig{}) failed: %v", err)
+	}
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:45000")
+	if err != nil {
+		t.Fatalf("failed to resolve address: %v", err)
+	}
+	abandonedConnection(t, s, 1, addr)
+
+	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: addr})
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Tunnel(&testDataStream{ctx: ctx, data: &tpb.Data{Tag: 1}})
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Tunnel() want error for abandoned session, got nil")
+		}
+	case <-time.After(deadlockTimeout):
+		t.Fatal("Tunnel blocked delivering a stream with no receiver")
+	}
+}
+
+func TestHandleSessionAbandonReleasesConnection(t *testing.T) {
+	s, err := NewServer(ServerConfig{})
+	if err != nil {
+		t.Fatalf("NewServer(ServerConfig{}) failed: %v", err)
+	}
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:45000")
+	if err != nil {
+		t.Fatalf("failed to resolve address: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := s.handleSession(ctx, 7, addr, Target{ID: "target1"}, &registerTestStream{maxSends: 10}); err == nil {
+		t.Fatal("handleSession() want context error, got nil")
+	}
+	if ch := s.connection(7, addr); ch != nil {
+		t.Fatal("connection for abandoned session still registered; late responses would be orphaned")
+	}
+}

--- a/tunnel/tunnel_test.go
+++ b/tunnel/tunnel_test.go
@@ -713,7 +713,10 @@ func TestServerTunnelSuccess(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to resolve address: %v", err)
 		}
-		i := make(chan ioOrErr)
+		// Connection channels are buffered (cap 1) so session responses can be
+		// delivered without blocking; Tunnel drops the stream if neither the
+		// buffer nor a receiver is available.
+		i := make(chan ioOrErr, 1)
 		s.addConnection(1, addr, i)
 		ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: addr})
 		go func() {

--- a/tunnel/tunnel_test.go
+++ b/tunnel/tunnel_test.go
@@ -227,6 +227,16 @@ func (tc *tunnelClient) Tunnel(ctx context.Context, opts ...grpc.CallOption) (tp
 	return tc.tunStream, nil
 }
 
+type contextTunnelClient struct {
+	*tunnelClient
+	contexts chan context.Context
+}
+
+func (tc *contextTunnelClient) Tunnel(ctx context.Context, opts ...grpc.CallOption) (tpb.Tunnel_TunnelClient, error) {
+	tc.contexts <- ctx
+	return tc.tunStream, nil
+}
+
 type tunnelBlockingClient struct {
 	*tunnelClient
 	regStream tpb.Tunnel_RegisterClient
@@ -409,12 +419,41 @@ func TestDataIOStreamWrite(t *testing.T) {
 func TestDataIOStreamClose(t *testing.T) {
 	tds := &testDataStream{}
 	d := newIOStream(context.Background(), tds)
-	err := d.Close()
-	if err != nil {
-		t.Fatalf("Close() got %v, want nil", err)
+	if err := d.CloseWrite(); err != nil {
+		t.Fatalf("CloseWrite() got %v, want nil", err)
 	}
 	if !tds.data.GetClose() {
-		t.Errorf("Close() set close field to %t, want true", tds.data.GetClose())
+		t.Errorf("CloseWrite() set close field to %t, want true", tds.data.GetClose())
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close() got %v, want nil", err)
+	}
+	if _, err := d.Read(nil); err != context.Canceled {
+		t.Errorf("Read() after Close got %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestClientTunnelStreamCloseCancelsRPCContext(t *testing.T) {
+	tc := &contextTunnelClient{
+		tunnelClient: &tunnelClient{tunStream: &tunnelClientStream{maxSends: 10}},
+		contexts:     make(chan context.Context, 1),
+	}
+	c, err := NewClient(tc, ClientConfig{}, map[Target]struct{}{})
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+	stream, err := c.newTunnelStream(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("newTunnelStream() failed: %v", err)
+	}
+	rpcCtx := <-tc.contexts
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close() failed: %v", err)
+	}
+	select {
+	case <-rpcCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Close() did not cancel the context that owns the gRPC tunnel stream")
 	}
 }
 
@@ -842,6 +881,9 @@ func TestServerNewSession(t *testing.T) {
 			}
 			if rwc != nil && rwc != test.ioe.rwc {
 				t.Fatalf("NewSession() want %v, got %v", test.ioe.rwc, rwc)
+			}
+			if ch := s.connection(1, addr); ch != nil {
+				t.Fatal("NewSession() retained a completed connection")
 			}
 		})
 	}
@@ -1359,6 +1401,8 @@ func TestClientNewSessionAddConnectionFailure(t *testing.T) {
 		t.Fatalf("NewClient() failed: %v", err)
 	}
 	c.addr = addr
+	c.ctx = context.Background()
+	c.rs = &regSafeStream{regStream: &registerClientStream{maxSends: 10}}
 
 	if err := c.addConnection(-1, addr, make(chan ioOrErr)); err != nil {
 		t.Fatalf("AddConnection() failed: %v", err)
@@ -1388,6 +1432,7 @@ func TestClientNewSessionSendFailure(t *testing.T) {
 			sendErr: true,
 		},
 	}
+	c.ctx = context.Background()
 	_, err = c.NewSession(Target{})
 	if err == nil {
 		t.Fatalf("NewSession() got success, wanted error: %v", err)
@@ -1413,6 +1458,7 @@ func TestClientNewSessionRetChErr(t *testing.T) {
 			streamRecv: []*tpb.RegisterOp{},
 		},
 	}
+	c.ctx = context.Background()
 	go func() {
 		var ioe chan ioOrErr
 		for ioe == nil {
@@ -1423,5 +1469,60 @@ func TestClientNewSessionRetChErr(t *testing.T) {
 	_, err = c.NewSession(Target{})
 	if err == nil {
 		t.Fatalf("NewSession() got success, wanted error: %v", err)
+	}
+}
+
+func TestClientNewSessionSuccessReleasesConnection(t *testing.T) {
+	addr, err := net.ResolveTCPAddr("tcp", "192.168.0.1:22")
+	if err != nil {
+		t.Fatalf("failed to resolve addr: %v", err)
+	}
+	c, err := NewClient(nil, ClientConfig{}, map[Target]struct{}{})
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+	c.addr = addr
+	c.ctx = context.Background()
+	c.rs = &regSafeStream{regStream: &registerClientStream{maxSends: 10}}
+
+	go func() {
+		for {
+			if ch := c.connection(-1, addr); ch != nil {
+				ch <- ioOrErr{rwc: newIOStream(context.Background(), &testDataStream{})}
+				return
+			}
+		}
+	}()
+
+	rwc, err := c.NewSession(Target{ID: "target"})
+	if err != nil {
+		t.Fatalf("NewSession() failed: %v", err)
+	}
+	defer rwc.Close()
+	if ch := c.connection(-1, addr); ch != nil {
+		t.Fatal("NewSession() retained a completed connection")
+	}
+}
+
+func TestClientNewSessionContextCancellationReleasesConnection(t *testing.T) {
+	addr, err := net.ResolveTCPAddr("tcp", "192.168.0.1:22")
+	if err != nil {
+		t.Fatalf("failed to resolve addr: %v", err)
+	}
+	c, err := NewClient(nil, ClientConfig{}, map[Target]struct{}{})
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+	c.addr = addr
+	c.ctx = context.Background()
+	c.rs = &regSafeStream{regStream: &registerClientStream{maxSends: 10}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := c.NewSessionContext(ctx, Target{ID: "target"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("NewSessionContext() got %v, want %v", err, context.Canceled)
+	}
+	if ch := c.connection(-1, addr); ch != nil {
+		t.Fatal("NewSessionContext() retained a canceled connection")
 	}
 }


### PR DESCRIPTION
## Summary

- backport the abandoned session waiter deadlock fix from upstream PR #94
- cancel the exact context that owns each gRPC tunnel stream so `Close` releases grpc-go stream goroutines
- remove completed and canceled sessions from endpoint bookkeeping
- add context-aware client session creation and tie per-session streams to registration lifetime
- preserve TCP half-close behavior while tearing down both copy directions on errors
- fix target-map locking and peer-target deletion

This addresses the leak observed in Sourcegraph CLO-334, where closed sessions retained goroutines in `grpc.newClientStreamWithParams.func4` because the RPC-owning context was never canceled.

## Verification

- `go test -race ./...`
- `go vet ./...`
